### PR TITLE
runTestAtCursor, requires and subdirectory support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 **/debug.log
 .vscode/symbols.json
+.history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Pays attention to PATHEXT environment variable.
 - Feature: Rerun failed tests
 - Feature: Rerun last set of tests
 - Feature: Dump severe error to output channel
-- Fix: When selecting tests, it did not use Mocha options in workspace settings
+- Fix: When selecting tests, it did not use Mocha options in  settings
 
 0.0.1 (2016-04-25)
 =====

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Because your tests may requires a newer version of Node.js than the one powering
 
 When the test is being run, we will add `NODE_PATH` to point to your workspace `node_modules` folder to help [resolving external modules](https://nodejs.org/api/modules.html#modules_loading_from_the_global_folders).
 
+When you ask to run the test under cursor position, the extension will parse the current file and look for matching tests or suites.
+If the file contains tests or suites defined using template strings or via dynamic generation, the regular expression `(.+)` will be used as a placeholder in order to have a better matching without having to evaluate the file twice.
+This implies that more tests than expected might be run.
+
 ## Fit yourself
 
 No one shoe could fit everyone. You may need to turn some switches on to fit your project. Please [file us](https://github.com/cspotcode/vscode-mocha-latte/issues/new/) an issue if you think there is a better way to fit you and the others.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ You can run tests by:
 * All tests in the workspace
 * All or failed tests in last run
 * Tests that match a Regular Expression
+* Tests that the current cursor position (or the current file)
 * One test that you pick from a list
 
 ### How it works
@@ -74,6 +75,7 @@ Following commands are also supported:
 | `mocha.runAllTests` | Mocha: Run all tests |
 | `mocha.runFailedTests` | Mocha: Run failed tests |
 | `mocha.runLastSetAgain` | Mocha: Run last set again |
+| `mocha.runTestAtCursor` | Mocha: Run tests matching the current cursor position or the current active file |
 | `mocha.runTestsByPattern` | Mocha: Run tests matching a pattern |
 | `mocha.selectAndRunTest` | Mocha: Select and run a test |
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Under File > Preferences > Workspace Settings, you can configure [Mocha options]
 
 // Mocha: Environment variables to run your tests
 "mocha.env": {},
+
+// Mocha: Subdirectory in the Workspace where run mocha from
+"mocha.subfolder": "",
+
+// Mocha: List of files to require before running mocha
+"mocha.requires": [],
 ```
 
 ### Setting a keyboard shortcut

--- a/config.js
+++ b/config.js
@@ -17,3 +17,16 @@ exports.options = function options() {
 exports.files = function files() {
   return getConfiguration().files;
 };
+
+exports.subdirectory = function subdirectory() {
+  return getConfiguration().subdirectory;
+};
+
+exports.requires = function requires() {
+  const files = getConfiguration().requires || [];
+
+  if(!Array.isArray(files))
+    throw new Error("mocha.requires configuration must be an array of files");
+
+  return files.map(s => s.toString());
+};

--- a/extension.js
+++ b/extension.js
@@ -29,27 +29,39 @@ function activate(context) {
   const subscriptions = context.subscriptions;
 
   subscriptions.push(vscode.commands.registerCommand('mocha.runAllTests', function () {
-    runAllTests();
+    if (hasWorkspace()) {
+      runAllTests();
+    }
   }));
 
   subscriptions.push(vscode.commands.registerCommand('mocha.runTestAtCursor', function () {
-    runTestAtCursor();
+    if (hasWorkspace()) {
+      runTestAtCursor();
+    }
   }));
 
   subscriptions.push(vscode.commands.registerCommand('mocha.selectAndRunTest', function () {
-    selectAndRunTest();
+    if (hasWorkspace()) {
+      selectAndRunTest();
+    }
   }));
 
   subscriptions.push(vscode.commands.registerCommand('mocha.runFailedTests', function () {
-    runFailedTests();
+    if (hasWorkspace()) {
+      runFailedTests();
+    }
   }));
 
   subscriptions.push(vscode.commands.registerCommand('mocha.runTestsByPattern', function () {
-    runTestsByPattern();
+    if (hasWorkspace()) {
+      runTestsByPattern();
+    }
   }));
 
   subscriptions.push(vscode.commands.registerCommand('mocha.runLastSetAgain', function () {
-    runLastSetAgain();
+    if (hasWorkspace()) {
+      runLastSetAgain();
+    }
   }));
 }
 
@@ -60,6 +72,21 @@ function deactivate() {
 }
 
 exports.deactivate = deactivate;
+
+function hasWorkspace() {
+  const root = vscode.workspace.rootPath;
+  const validWorkspace = typeof root === "string" && root.length;
+
+  console.log(root);
+  console.log(vscode);
+  console.log(validWorkspace);
+
+  if(!validWorkspace) {
+    vscode.window.showErrorMessage('Please open a folder before trying to execute Mocha.');
+  }
+
+  return validWorkspace;
+}
 
 function fork(jsPath, args, options) {
   return findNodeJSPath().then(execPath => new Promise((resolve, reject) => {

--- a/fork.js
+++ b/fork.js
@@ -12,6 +12,9 @@ const
   access = Promise.promisify(fs.access);
 
 function fork(jsPath, args, options) {
+  // Make sure mocha is executed in the right folder
+  options.cwd = path.dirname(options.env.NODE_PATH);
+
   return nodeJSPath().then(
     execPath => new Promise((resolve, reject) => {
       resolve(ChildProcess.spawn(

--- a/mochashim.js
+++ b/mochashim.js
@@ -26,7 +26,7 @@ function stripWarnings(text) { // Remove node.js warnings, which would make JSON
   return text.replace(/\(node:\d+\) DeprecationWarning:\s[^\n]+/g, "");
 }
 
-function runTests(testFiles, grep) {
+function runTests(testFiles, grep, messages) {
   // Allow the user to choose a different subfolder
   const rootPath = applySubdirectory(vscode.workspace.rootPath);
 
@@ -52,6 +52,12 @@ function runTests(testFiles, grep) {
 
     outputChannel.appendLine(`Running Mocha with Node.js at ${process.spawnfile}\n`);
 
+    if (messages) {
+      for (let message of messages) {
+        outputChannel.append(`${message}\n`);
+      }
+    }
+    
     const stderrBuffers = [];
 
     process.stderr.on('data', data => {

--- a/mochashim.js
+++ b/mochashim.js
@@ -13,8 +13,22 @@ function envWithNodePath(rootPath) {
   }, config.env());
 }
 
+function applySubdirectory(rootPath){
+  const subdirectory = config.subdirectory()
+
+  if(subdirectory)
+    rootPath = path.resolve(rootPath, subdirectory);
+
+  return rootPath;
+}
+
+function stripWarnings(text) { // Remove node.js warnings, which would make JSON parsing fail
+  return text.replace(/\(node:\d+\) DeprecationWarning:\s[^\n]+/g, "");
+}
+
 function runTests(testFiles, grep) {
-  const rootPath = vscode.workspace.rootPath;
+  // Allow the user to choose a different subfolder
+  const rootPath = applySubdirectory(vscode.workspace.rootPath);
 
   return fork(
     path.resolve(module.filename, '../worker/runtest.js'),
@@ -23,6 +37,7 @@ function runTests(testFiles, grep) {
         files: testFiles,
         options: config.options(),
         grep,
+        requires: config.requires(),
         rootPath
       })
     ],
@@ -58,7 +73,7 @@ function runTests(testFiles, grep) {
         let resultJSON;
 
         try {
-          resultJSON = stderrText && JSON.parse(stderrText);
+          resultJSON = stderrText && JSON.parse(stripWarnings(stderrText));
         } catch (ex) {
           code = 1;
         }
@@ -76,6 +91,9 @@ function runTests(testFiles, grep) {
 }
 
 function findTests(rootPath) {
+  // Allow the user to choose a different subfolder
+  rootPath = applySubdirectory(rootPath);
+
   return fork(
     path.resolve(module.filename, '../worker/findtests.js'),
     [
@@ -85,6 +103,7 @@ function findTests(rootPath) {
           glob: config.files().glob,
           ignore: config.files().ignore
         },
+        requires: config.requires(),
         rootPath
       })
     ],
@@ -116,7 +135,7 @@ function findTests(rootPath) {
         let resultJSON;
 
         try {
-          resultJSON = stderrText && JSON.parse(stderrText);
+          resultJSON = stderrText && JSON.parse(stripWarnings(stderrText));
         } catch (ex) {
           code = 1;
         }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   ],
   "activationEvents": [
     "onCommand:mocha.runAllTests",
+    "onCommand:mocha.runTestAtCursor",
     "onCommand:mocha.selectAndRunTest",
     "onCommand:mocha.runFailedTests",
     "onCommand:mocha.runTestsByPattern",
@@ -38,6 +39,10 @@
       {
         "command": "mocha.runAllTests",
         "title": "Mocha: Run all tests"
+      },
+      {
+        "command": "mocha.runTestAtCursor",
+        "title": "Mocha: Run test at cursor"
       },
       {
         "command": "mocha.selectAndRunTest",
@@ -70,9 +75,14 @@
           "type": "string"
         },
         "mocha.files.ignore": {
-          "default": ["**/.git/**/*", "**/node_modules/**/*"],
+          "default": [
+            "**/.git/**/*",
+            "**/node_modules/**/*"
+          ],
           "description": "Mocha: Globs to ignore when searching for test files",
-          "type": ["string"]
+          "type": [
+            "string"
+          ]
         },
         "mocha.env": {
           "default": {},
@@ -85,6 +95,7 @@
     "vscode": "0.11.x"
   },
   "dependencies": {
+    "babylon": "^6.13.1",
     "bluebird": "^3.3.5",
     "escape-regexp": "0.0.1",
     "glob": "^7.0.3",

--- a/parser.js
+++ b/parser.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const babylon = require('babylon');
+
+function isValidTest(token){
+  const expression = token.expression;
+
+  return token.type === "ExpressionStatement" && expression.type === "CallExpression" // This is a function call
+    && ["describe", "it"].indexOf(expression.callee.name) !== -1 // This is a valid mocha test context
+    && expression.arguments.length === 2 && expression.arguments[0].type === "StringLiteral" && expression.arguments[1].type === "FunctionExpression"; // This is a valid test definition
+}
+
+function detectTests(body, path, tests){
+  body.filter(isValidTest).forEach(token => {
+    const name = token.expression.arguments[0].value;
+
+    // Add the test
+    tests.push({depth: path.length, label: path.concat(name).join(" "), start: token.loc.start.line, end: token.loc.end.line});
+
+    // Parse the called function
+    detectTests(token.expression.arguments[1].body.body, path.concat(name), tests);
+  });
+}
+
+module.exports.getTests = function getTests(text){
+  const ast = babylon.parse(
+    text,
+    {sourceType: "import", allowReturnOutsideFunction: true, allowImportExportEverywhere: true}
+  );
+
+  let tests = [];
+  // Start a depth-first visit of the tree
+  detectTests(ast.program.body, [], tests);
+
+  return tests.sort((a, b) => b.depth - a.depth); // Sort by descending depth in order to correct recognize nested positions
+}

--- a/parser.js
+++ b/parser.js
@@ -1,36 +1,97 @@
 'use strict';
 
 const babylon = require('babylon');
+const fs = require('fs');
+
+if(!RegExp.escape)
+  RegExp.escape = s => String(s).replace(/[\\^$*+?.()|[\]{}]/g, '\\$&');
 
 function isValidTest(token){
   const expression = token.expression;
 
   return token.type === "ExpressionStatement" && expression.type === "CallExpression" // This is a function call
-    && ["describe", "it"].indexOf(expression.callee.name) !== -1 // This is a valid mocha test context
-    && expression.arguments.length === 2 && expression.arguments[0].type === "StringLiteral" && expression.arguments[1].type === "FunctionExpression"; // This is a valid test definition
+    && ["describe", "it"].includes(expression.callee.name) && expression.arguments.length > 1 // This is a valid mocha test context
+    // It has two arguments, a string and function
+    && expression.arguments.length === 2
+    && ["TemplateLiteral", "StringLiteral"].includes(expression.arguments[0].type)
+    && ["FunctionExpression", "ArrowFunctionExpression"].includes(expression.arguments[1].type);
 }
 
-function detectTests(body, path, tests){
-  body.filter(isValidTest).forEach(token => {
-    const name = token.expression.arguments[0].value;
+function formatTestName(argument){
+  if(argument.type === "StringLiteral")
+    return RegExp.escape(argument.value);
+  else if(argument.type !== "TemplateLiteral")
+    return "(.+)";
 
-    // Add the test
-    tests.push({depth: path.length, label: path.concat(name).join(" "), start: token.loc.start.line, end: token.loc.end.line});
+  let tokens = [];
 
-    // Parse the called function
-    detectTests(token.expression.arguments[1].body.body, path.concat(name), tests);
-  });
+  for(let token of argument.expressions)
+    tokens.push({start: token.start, value: '(.+)'});
+
+  for(let token of argument.quasis)
+    tokens.push({start: token.start, value: RegExp.escape(token.value.raw)});
+
+  return tokens.sort((a, b) => a.start - b.start).map(t => t.value).join('');
 }
 
-module.exports.getTests = function getTests(text){
-  const ast = babylon.parse(
-    text,
-    {sourceType: "import", allowReturnOutsideFunction: true, allowImportExportEverywhere: true}
-  );
+function outSideCursor(position, cursor){
+  const start = position.start;
+  const end = position.end;
 
+  const afterCursor = start.line > cursor.row || (start.line === cursor.row && start.column > cursor.column);
+  const beforeCursor = end.line < cursor.row || (end.line == cursor.row && end.column < cursor.column);
+  return afterCursor || beforeCursor;
+}
+
+function detectTests(body, path, tests, cursor){
+  if(body.type === "BlockStatement") // For blocks, fetch the list of statements
+    body = body.body;
+
+  for(let token of body){ // For all statements
+    const expression = token.expression;
+    const position = token.loc;
+
+    // The definition is outside cursor position, ignore it
+    if(outSideCursor(position, cursor))
+      continue;
+
+    if(isValidTest(token)){ // This is a valid mocha test context
+      const newPath = Array.from(path).concat(formatTestName(token.expression.arguments[0])); // Add the new definition to the path
+      tests.push({depth: newPath.length, label: `^(${newPath.join(" ")})`, start: position.start.line, end: position.end.line}); // Add the test
+
+      if(expression.callee.name === "describe") // Since this defines a new suite, visit the block
+        detectTests(expression.arguments[1].body, newPath, tests, cursor);
+    }else if(token.body) // This is a block statement, visit the block without changing the path
+      detectTests(token.body, path, tests, cursor);
+  }
+}
+
+module.exports.getTests = function getTests(text, selection){
+  const cursor = {row: selection.line + 1, column: selection.character};
+  const ast = babylon.parse(text, {sourceType: "import", allowReturnOutsideFunction: true, allowImportExportEverywhere: true});
+
+  fs.writeFileSync("/tmp/ast.json", JSON.stringify(ast, null, 2));
   let tests = [];
   // Start a depth-first visit of the tree
-  detectTests(ast.program.body, [], tests);
 
-  return tests.sort((a, b) => b.depth - a.depth); // Sort by descending depth in order to correct recognize nested positions
+  try{
+    detectTests(ast.program.body, [], tests, cursor);
+    return tests;
+  }catch(e){
+    console.error(e);
+    return [];
+  }
+}
+
+module.exports.getTestAtCursor = function getTestAtCursor(text, selection){
+  // Now order tests by depth and then line - The cursor is
+  const sortedTests = module.exports.getTests(text, selection).sort((a, b) => {
+    if(b.depth !== a.depth) // Sort by descending depth in order to correct recognize nested positions
+      return b.depth - a.depth;
+
+    // Upon same depth, sort by start line
+    return b.start - a.start;
+  });
+
+  return sortedTests[0];
 }

--- a/runner.js
+++ b/runner.js
@@ -20,8 +20,8 @@ Runner.prototype.loadTestFiles = function () {
     });
 };
 
-Runner.prototype._runMocha = function (testFiles, grep) {
-  return MochaShim.runTests(dedupeStrings(testFiles), grep)
+Runner.prototype._runMocha = function (testFiles, grep, logMessages) {
+  return MochaShim.runTests(dedupeStrings(testFiles), grep, logMessages)
     .then(result => {
       this.lastRunResult = result;
 
@@ -35,8 +35,8 @@ Runner.prototype._runMocha = function (testFiles, grep) {
     });
 };
 
-Runner.prototype.runAll = function () {
-  return this._runMocha(this.tests.map(test => test.file));
+Runner.prototype.runAll = function (logMessages) {
+  return this._runMocha(this.tests.map(test => test.file), null, logMessages);
 };
 
 Runner.prototype.runWithGrep = function (grep) {

--- a/worker/findtests.js
+++ b/worker/findtests.js
@@ -10,6 +10,9 @@ const
 const
   args = JSON.parse(process.argv[2]);
 
+for(let file of args.requires)
+  require(file);
+
 createMocha(args.rootPath, args.options, args.files.glob, args.files.ignore)
   .then(mocha => crawlTests(mocha.suite))
   .then(tests => console.error(JSON.stringify(tests, null, 2)))

--- a/worker/runtest.js
+++ b/worker/runtest.js
@@ -12,6 +12,9 @@ const
   args = JSON.parse(process.argv[2]),
   options = args.options;
 
+for(let file of args.requires)
+  require(file);
+
 if (Object.keys(options || {}).length) {
   console.log(`Applying Mocha options:\n${indent(JSON.stringify(options, null, 2))}`);
 } else {


### PR DESCRIPTION
Hi!
I added the following functionality to this awesome extension:

1. New `runTestAtCursor` command: Using the [babylon](https://github.com/babel/babylon) parser, VS Code will detect the test at the current cursor position (or the single file as callback) and run it.
2. New `mocha.subdirectory` option: A directory in the workspace where to run mocha from. This is useful for complex workspaces when multiple application are stored.
3. New `mocha.requires` option: A list of files to require before running mocha. This is useful when some files (like `babel-register`) must be required in order to run test suite succesfully. This alleviates the lack of support for `mocha.opts`file since this, to me, was the only remaining option to add.

Hope this helps!
  Paolo