### PR TITLE
Support for node_options configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Under File > Preferences > Workspace Settings, you can configure [Mocha options]
 
 // Mocha: Environment variables to run your tests
 "mocha.env": {},
+
+// Mocha: Options to pass to node executable
+"mocha.node_options": [],
+
 ```
 
 ### Setting a keyboard shortcut

--- a/config.js
+++ b/config.js
@@ -14,6 +14,10 @@ exports.options = function options() {
   return getConfiguration().options;
 };
 
+exports.node_options = function options() {
+  return getConfiguration().node_options;
+};
+
 exports.files = function files() {
   return getConfiguration().files;
 };

--- a/fork.js
+++ b/fork.js
@@ -6,7 +6,8 @@ const
   path = require('path'),
   Promise = require('bluebird'),
   trimArray = require('./utils').trimArray,
-  vscode = require('vscode');
+  vscode = require('vscode'),
+  config = require('./config');
 
 const
   access = Promise.promisify(fs.access);
@@ -16,7 +17,7 @@ function fork(jsPath, args, options) {
     execPath => new Promise((resolve, reject) => {
       resolve(ChildProcess.spawn(
         execPath,
-        [ jsPath ].concat(args),
+        config.node_options().concat([ jsPath ]).concat(args),
         options
       ))
     }),

--- a/package.json
+++ b/package.json
@@ -77,6 +77,10 @@
         "mocha.env": {
           "default": {},
           "description": "Mocha: Environment variables to run your tests"
+        },
+        "mocha.node_options": {
+          "default": [],
+          "description": "Mocha: Options to pass to node executable"
         }
       }
     }

--- a/worker/findtests.js
+++ b/worker/findtests.js
@@ -8,7 +8,7 @@ const
   trimArray = require('../utils').trimArray;
 
 const
-  args = JSON.parse(process.argv[2]);
+  args = JSON.parse(process.argv[process.argv.length - 1]);
 
 createMocha(args.rootPath, args.options, args.files.glob, args.files.ignore)
   .then(mocha => crawlTests(mocha.suite))

--- a/worker/runtest.js
+++ b/worker/runtest.js
@@ -9,7 +9,7 @@ const
   Promise = require('bluebird');
 
 const
-  args = JSON.parse(process.argv[2]),
+  args = JSON.parse(process.argv[process.argv.length - 1]),
   options = args.options;
 
 if (Object.keys(options || {}).length) {


### PR DESCRIPTION
Adds support for configuring the options that will be passed to node executable. This is useful for passing `--harmony` to recent node versions, for example.

Example (with node 7.3.0):

**test/test.js**
```
const expect = require('chai').expect;

describe('my test', async () => {
  it('is ok', async () => {
    expect(true).to.be.true;
  })
})
```

**Output without any flag:**
```
/Users/scinos/src/example/test/test.js:3
describe('my test', async () => {
                          ^
SyntaxError: Unexpected token (
```

**Output with the config:** `"mocha.node_options": ["--harmony"]`

```
Running Mocha with Node.js at /Users/scinos/.nvm/versions/node/v7.3.0/bin/node

No Mocha options are configured. You can set it under File > Preferences > Workspace Settings.

Test file(s):
  /Users/scinos/src/example/test/test.js

  my test
    ✓ is ok
```