### PR TITLE
Resolve mocha.requires entries that are relative paths, to their absolute path.

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const path = require('path');
+
 exports.trimArray = function trimArray(array) {
   return array.reduce((trimmed, item) => {
     item && trimmed.push(item);
@@ -7,3 +9,9 @@ exports.trimArray = function trimArray(array) {
     return trimmed;
   }, []);
 };
+
+exports.resolveRelativePath = function(file) {
+  return file.substr(0,1) === '.' ?
+    path.join(process.cwd(), file):
+    file;
+}

--- a/worker/findtests.js
+++ b/worker/findtests.js
@@ -5,13 +5,13 @@ const
   Mocha = require('mocha'),
   path = require('path'),
   Promise = require('bluebird'),
-  trimArray = require('../utils').trimArray;
+  { trimArray, resolveRelativePath } = require('../utils');
 
 const
   args = JSON.parse(process.argv[process.argv.length - 1]);
 
 for(let file of args.requires)
-  require(file);
+  require(resolveRelativePath(file));
 
 createMocha(args.rootPath, args.options, args.files.glob, args.files.ignore)
   .then(mocha => crawlTests(mocha.suite))

--- a/worker/runtest.js
+++ b/worker/runtest.js
@@ -6,14 +6,15 @@ const
   fs = require('fs'),
   Mocha = require('mocha'),
   path = require('path'),
-  Promise = require('bluebird');
+  Promise = require('bluebird'),
+  { trimArray, resolveRelativePath } = require('../utils');
 
 const
   args = JSON.parse(process.argv[process.argv.length - 1]),
   options = args.options;
 
 for(let file of args.requires)
-  require(file);
+  require(resolveRelativePath(file));
 
 if (Object.keys(options || {}).length) {
   console.log(`Applying Mocha options:\n${indent(JSON.stringify(options, null, 2))}`);


### PR DESCRIPTION
Fixes #13 

The changes will identify relative paths by looking for a dot as the first character, and if found it will resolve them to an absolute path, relative to the current working directory (which is the root of the project)