### PR TITLE
Add the declaration of the missing settings mocha.requires and mocha.subfolder

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,14 @@
         "mocha.node_options": {
           "default": [],
           "description": "Mocha: Options to pass to node executable"
+        },
+        "mocha.requires": {
+            "default": [],
+            "description": "Mocha: List of files to require before running mocha"
+        },
+        "mocha.subfolder": {
+            "default": "",
+            "description": "Mocha: Subdirectory in the Workspace where run mocha from"
         }
       }
     }


### PR DESCRIPTION
Fixes #15 

Adds the declaration for the **mocha.subfolder** and **mocha.requires** settings using the message and default value as described in the documentation.